### PR TITLE
Fixes useAccountBalance and maxBal in swap panel

### DIFF
--- a/src/components/CurrencyInputPanel/SwapCurrencyInputPanel.tsx
+++ b/src/components/CurrencyInputPanel/SwapCurrencyInputPanel.tsx
@@ -272,7 +272,7 @@ const SwapCurrencyInputPanel = forwardRef<HTMLInputElement, SwapCurrencyInputPan
   ) => {
     const [modalOpen, setModalOpen] = useState(false)
     const { address: account, chainId } = useAccountDetails()
-    const selectedCurrencyBalance = useCurrencyBalance(account ?? undefined, currency ?? undefined)
+    // const selectedCurrencyBalance = useCurrencyBalance(account ?? undefined, currency ?? undefined)
     const theme = useTheme()
     const { formatCurrencyAmount } = useFormatter()
 
@@ -314,7 +314,8 @@ const SwapCurrencyInputPanel = forwardRef<HTMLInputElement, SwapCurrencyInputPan
             <ThemedText.SubHeaderSmall style={{ userSelect: 'none', textTransform: 'uppercase' }}>
               {label}
             </ThemedText.SubHeaderSmall>
-            {showMaxButton && selectedCurrencyBalance ? (
+            {/* {showMaxButton && selectedCurrencyBalance ? ( */}
+            {showMaxButton ? (
               <StyledBalanceMax onClick={onMax}>
                 <Trans>Max</Trans>
               </StyledBalanceMax>

--- a/src/hooks/starknet-react.ts
+++ b/src/hooks/starknet-react.ts
@@ -1,11 +1,12 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Connector, useAccount, useBalance, useConnect, useProvider } from '@starknet-react/core'
 import { AccountInterface, constants } from 'starknet'
-import { ChainId, Currency, Token } from '@vnaysn/jediswap-sdk-core'
+import { ChainId, Currency, CurrencyAmount, Token } from '@vnaysn/jediswap-sdk-core'
 import { WETH } from '@jediswap/sdk'
 import { useDefaultActiveTokens } from './Tokens'
 import formatBalance from 'utils/formatBalance'
 import { useQuery } from 'react-query'
+import { ethers } from 'ethers'
 // Define the type for the balances object
 declare enum StarknetChainId {
   SN_MAIN = '0x534e5f4d41494e',
@@ -69,6 +70,7 @@ export const useAccountBalance = (currency: Currency | undefined) => {
     address,
     watch: true,
   })
-
-  return { balance: data?.formatted, formatted: formatBalance(data?.formatted) }
+  const balance = data ? ethers.utils.formatUnits(data.value, data.decimals) : null  //data?.formatted is not accurately implemented, so we a convert balance to String by ourselves
+  const balanceCurrencyAmount =  data && currency ? CurrencyAmount.fromRawAmount(currency, data.value.toString()) : null
+  return { balance, formatted: formatBalance(balance), balanceCurrencyAmount }
 }


### PR DESCRIPTION
Fixes #201 

1. more precise balance from useAccountBalance
2. added balanceCurrencyAmount that should be used when possible instead of balance (because this is a string value)
3. Fixed showMaxButton in the swap page
4. Added additional swapInputError because useDerivedSwapInfo does not give an error if the input value is slightly higher than the actual wallet balance.